### PR TITLE
Introducing XSRFProbe Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
   <a href="https://travis-ci.org/0xInfection/XSRFProbe">
     <img src="https://img.shields.io/badge/Build-Passing-brightgreen.svg?logo=travis">
   </a>
+  <a href="https://gurubase.io/g/xsrfprobe">
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20XSRFProbe%20Guru-006BFF">
+  </a>
 </p>
 
 ### About:


### PR DESCRIPTION
Hello 

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [XSRFProbe Guru](https://gurubase.io/g/xsrfprobe) to Gurubase. XSRFProbe Guru uses the data from this repo and data from the  [docs](https://github.com/0xInfection/XSRFProbe/wiki) to answer questions by leveraging the LLM.

In this PR, I showcased the "XSRFProbe Guru" badge, which highlights that XSRFProbe now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable XSRFProbe Guru in Gurubase, just let me know that's totally fine.